### PR TITLE
ci(release): 提升发布元数据恢复能力

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   frontend-static-checks:
     name: Frontend Static Checks

--- a/.github/workflows/finalize-updater.yml
+++ b/.github/workflows/finalize-updater.yml
@@ -1,0 +1,56 @@
+name: Finalize Updater Metadata
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to finalize, for example v0.0.9'
+        required: true
+        type: string
+
+concurrency:
+  group: finalize-updater-${{ inputs.version }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  finalize-updater:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download release metadata and signatures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          gh release download "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --pattern latest.json \
+            --output latest.json
+
+          gh release download "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --pattern '*.sig'
+
+      - name: Generate updater metadata
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node scripts/finalize-updater-metadata.mjs
+
+      - name: Upload updater metadata aliases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release upload "$VERSION" latest.json darwin.json windows.json linux.json \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   RELEASE_BODY: |
     ## 下载建议
 
@@ -261,6 +262,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Verify and publish updater metadata aliases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -276,82 +280,7 @@ jobs:
           gh release download "$VERSION" \
             --repo "${{ github.repository }}" \
             --pattern '*.sig'
-
-          APP_VERSION="${VERSION#v}"
-          BASE_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION"
-          NOTES="$(jq -r '.notes // ""' latest.json)"
-          PUB_DATE="$(jq -r '.pub_date // ""' latest.json)"
-          read_sig() {
-            tr -d '\r\n' < "$1.sig"
-          }
-
-          DARWIN_ARM_SIG="$(read_sig 'Douyin.Downloader_aarch64.app.tar.gz')"
-          DARWIN_X64_SIG="$(read_sig 'Douyin.Downloader_x64.app.tar.gz')"
-          WINDOWS_SIG="$(read_sig "Douyin.Downloader_${APP_VERSION}_x64-setup.exe")"
-          WINDOWS_PORTABLE_SIG="$(read_sig "Douyin-Downloader_${APP_VERSION}_x64_portable.exe")"
-          LINUX_APPIMAGE_SIG="$(read_sig "Douyin.Downloader_${APP_VERSION}_amd64.AppImage")"
-          LINUX_DEB_SIG="$(read_sig "Douyin.Downloader_${APP_VERSION}_amd64.deb")"
-          LINUX_RPM_ASSET="Douyin.Downloader-${APP_VERSION}-1.x86_64.rpm"
-          LINUX_RPM_SIG="$(read_sig "$LINUX_RPM_ASSET")"
-
-          jq -n \
-            --arg version "$APP_VERSION" \
-            --arg notes "$NOTES" \
-            --arg pub_date "$PUB_DATE" \
-            --arg darwin_arm_sig "$DARWIN_ARM_SIG" \
-            --arg darwin_arm_url "$BASE_URL/Douyin.Downloader_aarch64.app.tar.gz" \
-            --arg darwin_x64_sig "$DARWIN_X64_SIG" \
-            --arg darwin_x64_url "$BASE_URL/Douyin.Downloader_x64.app.tar.gz" \
-            --arg windows_sig "$WINDOWS_SIG" \
-            --arg windows_url "$BASE_URL/Douyin.Downloader_${APP_VERSION}_x64-setup.exe" \
-            --arg windows_portable_sig "$WINDOWS_PORTABLE_SIG" \
-            --arg windows_portable_url "$BASE_URL/Douyin-Downloader_${APP_VERSION}_x64_portable.exe" \
-            --arg linux_appimage_sig "$LINUX_APPIMAGE_SIG" \
-            --arg linux_appimage_url "$BASE_URL/Douyin.Downloader_${APP_VERSION}_amd64.AppImage" \
-            --arg linux_deb_sig "$LINUX_DEB_SIG" \
-            --arg linux_deb_url "$BASE_URL/Douyin.Downloader_${APP_VERSION}_amd64.deb" \
-            --arg linux_rpm_sig "$LINUX_RPM_SIG" \
-            --arg linux_rpm_url "$BASE_URL/$LINUX_RPM_ASSET" \
-            '{
-              version: $version,
-              notes: $notes,
-              pub_date: $pub_date,
-              platforms: {
-                "darwin-aarch64": { signature: $darwin_arm_sig, url: $darwin_arm_url },
-                "darwin-aarch64-app": { signature: $darwin_arm_sig, url: $darwin_arm_url },
-                "darwin-x86_64": { signature: $darwin_x64_sig, url: $darwin_x64_url },
-                "darwin-x86_64-app": { signature: $darwin_x64_sig, url: $darwin_x64_url },
-                "windows-x86_64": { signature: $windows_sig, url: $windows_url },
-                "windows-x86_64-nsis": { signature: $windows_sig, url: $windows_url },
-                "windows-x86_64-portable": { signature: $windows_portable_sig, url: $windows_portable_url },
-                "linux-x86_64": { signature: $linux_appimage_sig, url: $linux_appimage_url },
-                "linux-x86_64-appimage": { signature: $linux_appimage_sig, url: $linux_appimage_url },
-                "linux-x86_64-deb": { signature: $linux_deb_sig, url: $linux_deb_url },
-                "linux-x86_64-rpm": { signature: $linux_rpm_sig, url: $linux_rpm_url }
-              }
-            }' > latest.fixed.json
-
-          mv latest.fixed.json latest.json
-
-          jq -e --arg version "$APP_VERSION" '
-            .version == $version and
-            (.platforms["darwin-aarch64"].signature | length > 0) and
-            (.platforms["darwin-aarch64"].url | length > 0) and
-            (.platforms["darwin-x86_64"].signature | length > 0) and
-            (.platforms["darwin-x86_64"].url | length > 0) and
-            (.platforms["windows-x86_64"].signature | length > 0) and
-            (.platforms["windows-x86_64"].url | length > 0) and
-            (.platforms["windows-x86_64-portable"].signature | length > 0) and
-            (.platforms["windows-x86_64-portable"].url | length > 0) and
-            (.platforms["linux-x86_64"].signature | length > 0) and
-            (.platforms["linux-x86_64"].url | length > 0) and
-            (.platforms["linux-x86_64-rpm"].signature | length > 0) and
-            (.platforms["linux-x86_64-rpm"].url | length > 0)
-          ' latest.json
-
-          for target in darwin windows linux; do
-            cp latest.json "$target.json"
-          done
+          node scripts/finalize-updater-metadata.mjs
 
           gh release upload "$VERSION" latest.json darwin.json windows.json linux.json \
             --repo "${{ github.repository }}" \

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 <div align="center">
 
-<img src="src-tauri/icons/icon.png" width="128" height="128" alt="Logo">
+<img src="src-tauri/icons/icon.png" width="128" height="128" alt="Douyin Downloader Logo">
 
 # Douyin Downloader
 
-**抖音视频下载器 · Rust / Tauri 重构版**
+**抖音视频下载器 · Rust / Tauri 桌面重构版**
 
 [![Rust](https://img.shields.io/badge/Rust-1.77.2+-orange.svg?style=flat-square&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Tauri](https://img.shields.io/badge/Tauri-2.0-blue.svg?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
 [![CI](https://img.shields.io/github/actions/workflow/status/anYuJia/douyin-downloader-rust/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/anYuJia/douyin-downloader-rust/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/anYuJia/douyin-downloader-rust?style=flat-square)](https://github.com/anYuJia/douyin-downloader-rust/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg?style=flat-square)]()
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg?style=flat-square)](https://github.com/anYuJia/douyin-downloader-rust/releases/latest)
 
-基于 Rust + Tauri 2.0 的跨平台桌面版抖音下载工具，支持用户检索、批量下载、推荐视频浏览、点赞列表获取与实时下载进度。
+基于 Rust + Tauri 2.0 的跨平台桌面版抖音下载工具，支持用户检索、批量下载、推荐视频浏览、点赞列表获取、多媒体作品下载与实时下载进度。
 
 <p>
   <a href="https://github.com/anYuJia/douyin-downloader-rust/releases/latest"><strong>下载最新版</strong></a>
   ·
+  <a href="#界面预览"><strong>界面预览</strong></a>
+  ·
   <a href="#快速开始"><strong>快速开始</strong></a>
   ·
-  <a href="#从源码构建"><strong>源码运行</strong></a>
+  <a href="#从源码构建"><strong>源码构建</strong></a>
   ·
   <a href="#常见问题"><strong>常见问题</strong></a>
 </p>
@@ -31,35 +33,65 @@
 
 ## 项目简介
 
-本项目是 [DY_video_downloader](https://github.com/anYuJia/DY_video_downloader) 的 Rust 重构版本。
+Douyin Downloader 是 [DY_video_downloader](https://github.com/anYuJia/DY_video_downloader) 的 Rust / Tauri 重构版本，目标是把原先偏脚本化的下载流程整理成更轻量、稳定、易分发的桌面应用。
 
-相比 Python 打包版，当前版本更适合作为长期维护的桌面应用：
+相比 Python 打包版，当前版本更适合作为长期维护的桌面工具：
 
-- **更小体积**：打包后体积明显缩小
-- **更低内存**：原生应用运行开销更低
-- **更快启动**：无需 Python 运行时
-- **更易分发**：原生支持 Windows / macOS / Linux
-
----
-
-## 为什么做这个项目
-
-- 想把原先依赖 Python 运行时的工具，重构成更轻量的桌面应用
-- 想保留批量下载、推荐视频、点赞列表这类高频能力
-- 想让功能更集中，减少脚本式工具的使用门槛
+- **更轻量**：原生桌面应用，无需 Python 运行时
+- **更易分发**：支持 Windows / macOS / Linux 安装包与便携包
+- **更集中**：搜索、推荐、点赞、批量下载、历史管理集中在一个界面
+- **更清晰**：登录态、下载任务、文件位置和错误状态都有可见反馈
 
 ---
 
 ## 功能亮点
 
-- **用户检索**：支持昵称、抖音号、链接搜索用户
-- **批量下载**：一键下载用户全部作品
-- **推荐视频**：浏览推荐 feed，支持沉浸式预览
-- **点赞列表**：获取自己点赞的视频与作者列表
-- **多媒体支持**：支持视频、图集、Live Photo 等内容
-- **下载质量可选**：最高质量 / 兼容优先 / 最小体积
-- **实时进度**：下载任务实时显示进度与状态
-- **浏览器登录**：内置登录流程，便于获取可用 Cookie
+| 能力 | 说明 |
+|:---|:---|
+| 用户检索 | 支持昵称、抖音号、分享链接搜索用户 |
+| 批量下载 | 支持下载用户作品、点赞作品、作者列表作品 |
+| 推荐视频 | 支持推荐 feed 浏览与沉浸式播放器预览 |
+| 点赞列表 | 支持获取并浏览自己的点赞视频与点赞作者 |
+| 多媒体作品 | 支持视频、图集、Live Photo、混合媒体 |
+| 下载质量 | 支持最高质量、兼容优先、最小体积等策略 |
+| 实时进度 | 下载任务状态、当前进度、日志实时更新 |
+| 浏览器登录 | 内置登录窗口，用于获取可用 Cookie |
+| 本地管理 | 支持下载历史、文件搜索、批量打开和定位 |
+| 自动更新 | 基于 GitHub Release updater metadata 检查新版本 |
+
+---
+
+## 界面预览
+
+### 首页
+
+搜索用户、粘贴链接、进入推荐视频和我的下载入口。
+
+<p align="center">
+  <a href="docs/home.png">
+    <img src="docs/home.png" width="100%" alt="Douyin Downloader 首页">
+  </a>
+</p>
+
+### 用户详情
+
+查看用户资料、作品列表，并执行批量下载或单个作品下载。
+
+<p align="center">
+  <a href="docs/user_detail.png">
+    <img src="docs/user_detail.png" width="100%" alt="Douyin Downloader 用户详情">
+  </a>
+</p>
+
+### 播放器
+
+推荐视频和作品详情使用沉浸式预览，弱网场景会显示更明确的加载、重试和错误提示。
+
+<p align="center">
+  <a href="docs/playvideo.png">
+    <img src="docs/playvideo.png" width="100%" alt="Douyin Downloader 播放器">
+  </a>
+</p>
 
 ---
 
@@ -67,32 +99,26 @@
 
 ### 下载安装
 
-从 [Releases](../../releases/latest) 下载对应平台的安装包：
+从 [Releases](https://github.com/anYuJia/douyin-downloader-rust/releases/latest) 下载对应平台的安装包：
 
 | 平台 | 推荐文件 | 说明 |
 |:---|:---|:---|
-| Windows | `*_x64-setup.exe` | 常规安装版，适合长期使用 |
-| Windows | `*_x64_portable.exe` | 便携版，不需要安装 |
-| macOS Apple Silicon | `*_aarch64.dmg` / `*_macos-arm64_portable.zip` | M1/M2/M3 等芯片 |
-| macOS Intel | `*_x64.dmg` / `*_macos-x64_portable.zip` | Intel 芯片 |
-| Linux | `.deb` / `.rpm` / `.AppImage` | Debian/Ubuntu 优先用 `.deb`，Fedora/openSUSE/RHEL 优先用 `.rpm`，其他发行版可尝试 `.AppImage` |
+| Windows | `Douyin.Downloader_*_x64-setup.exe` | 常规安装版，适合长期使用 |
+| Windows | `Douyin-Downloader_*_x64_portable.exe` | 便携版，不需要安装 |
+| macOS Apple Silicon | `Douyin.Downloader_*_aarch64.dmg` / `*_macos-arm64_portable.zip` | M1/M2/M3/M4 等芯片 |
+| macOS Intel | `Douyin.Downloader_*_x64.dmg` / `*_macos-x64_portable.zip` | Intel 芯片 |
+| Linux Debian/Ubuntu | `Douyin.Downloader_*_amd64.deb` | 适合 Debian、Ubuntu、Linux Mint 等 |
+| Linux Fedora/openSUSE/RHEL | `Douyin.Downloader-*-1.x86_64.rpm` | 适合 RPM 系发行版 |
+| Linux 通用 | `Douyin.Downloader_*_amd64.AppImage` | 免安装便携运行 |
 
-### 包管理器分发
+`.sig`、`latest.json`、`windows.json`、`darwin.json`、`linux.json` 主要用于自动更新和签名校验，普通安装通常不需要手动下载。
 
-项目已准备 Homebrew Cask、Scoop 和 winget 的分发模板，见 [packaging/package-managers](packaging/package-managers)。这些模板会在正式提交到对应包管理器仓库后提供更方便的安装与更新方式。
+### 首次使用
 
-### 首次使用建议
-
-1. 先在设置中完成 Cookie / 登录配置
-2. 再使用搜索、推荐视频或点赞列表功能
-3. 最后根据需要进行单个下载或批量下载
-
-### Cookie、数据与隐私
-
-- Cookie 仅用于本地请求抖音相关接口，不会上传到本项目的服务器
-- 下载历史、应用配置和缓存数据保存在本机应用数据目录
-- 下载文件默认保存在设置中配置的下载目录，可在“我的下载”中打开或定位
-- 如果推荐、点赞或详情接口突然失效，优先检查 Cookie 是否过期或登录态是否被平台刷新
+1. 打开应用后，先在设置中完成 Cookie / 登录配置
+2. 使用搜索、推荐视频、点赞列表或粘贴链接解析内容
+3. 选择单个作品下载，或进入用户/点赞列表执行批量下载
+4. 在底部下载面板查看实时进度，在“我的下载”中管理本地文件
 
 > **macOS 用户**
 >
@@ -104,23 +130,21 @@
 
 ---
 
-## 界面预览
+## Cookie、数据与隐私
 
-| 首页 | 用户详情 | 播放器 |
-|:--:|:--:|:--:|
-| <img src="docs/home.png" width="100%" alt="主页"> | <img src="docs/user_detail.png" width="100%" alt="用户详情"> | <img src="docs/playvideo.png" width="100%" alt="视频播放"> |
-| 搜索、链接解析、推荐视频入口 | 用户信息与作品入口 | 推荐视频沉浸式预览 |
+- Cookie 仅用于本地请求抖音相关接口，不会上传到本项目的服务器
+- 下载历史、应用配置和缓存数据保存在本机应用数据目录
+- 下载文件默认保存在设置中配置的下载目录
+- 推荐视频、点赞列表和部分批量下载能力依赖有效登录态
+- 如果接口突然失效，优先检查 Cookie 是否过期、账号是否需要重新验证、网络是否可访问相关域名
 
 ---
 
-## 当前支持的使用场景
+## 包管理器分发
 
-- 搜索用户并查看用户详情
-- 批量下载用户作品
-- 获取并浏览推荐视频
-- 获取自己点赞的视频 / 作者列表
-- 下载视频、图集、Live Photo 等内容
-- 查看下载历史与本地文件
+项目已准备 Homebrew Cask、Scoop 和 winget 的分发模板，见 [packaging/package-managers](packaging/package-managers)。
+
+当前这些模板用于维护和提交包管理器清单。正式进入对应包管理器仓库后，将可以通过命令行安装和更新。
 
 ---
 
@@ -129,7 +153,7 @@
 ### 环境要求
 
 - Rust 1.77.2+
-- Node.js 18+（可选，用于前端开发）
+- Node.js 18+（可选，用于前端静态检查和分发脚本）
 - 系统依赖见 [Tauri 官方文档](https://tauri.app/start/prerequisites/)
 
 ### 开发模式运行
@@ -149,53 +173,60 @@ cd src-tauri
 cargo tauri build
 ```
 
+### 本地检查
+
+```bash
+cd src-tauri
+cargo fmt --check
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+前端静态检查：
+
+```bash
+for file in dist/js/*.js; do node --check "$file"; done
+```
+
 ---
 
 ## 技术栈
 
-- **后端**：Rust + Tauri 2.0
+- **桌面框架**：Tauri 2
+- **后端**：Rust、Tokio、Reqwest、Axum
 - **前端**：原生 HTML / CSS / JavaScript + Bootstrap 5
-- **通信**：桌面命令调用 + 实时状态推送
-
----
-
-## 使用说明
-
-- 推荐、点赞列表、批量下载等能力依赖有效登录态
-- 部分接口可能因抖音风控、Cookie 失效、网络环境等因素受影响
-- 推荐先使用内置登录 / Cookie 配置，再进行大批量操作
-- 应用更新通过 GitHub Release 中的 `latest.json` 元数据检查，网络无法访问 GitHub 时可能无法自动检查更新
-- 本项目更适合作为个人学习、研究和桌面工具使用
+- **更新机制**：Tauri updater + GitHub Release metadata
+- **分发产物**：Windows NSIS / portable exe、macOS dmg / app zip、Linux deb / rpm / AppImage
 
 ---
 
 ## 常见问题
 
-### 1. 为什么有些功能需要登录？
+### 为什么有些功能需要登录？
 
-推荐视频、点赞列表、部分批量下载能力依赖有效 Cookie / 登录态。未登录时，接口可能直接拒绝或返回不完整数据。
+推荐视频、点赞列表、部分批量下载能力依赖有效 Cookie / 登录态。未登录时，接口可能拒绝访问或返回不完整数据。
 
-### 2. 可以只下载单个视频吗？
+### 可以只下载单个视频吗？
 
 可以。除了批量下载，也支持通过粘贴链接解析后进行单个下载。
 
-### 3. 下载文件保存到哪里？
+### 下载文件保存到哪里？
 
-下载目录可以在设置中修改。历史记录页面也支持直接打开文件或定位到文件夹。
+下载目录可以在设置中修改。历史记录和“我的下载”页面也支持直接打开文件或定位到文件夹。
 
-### 4. 推荐视频接口为什么有时不稳定？
+### 推荐视频接口为什么有时不稳定？
 
 推荐流、详情、点赞等接口都可能受到平台风控、Cookie 状态和网络环境影响。这类现象属于预期范围。
 
-### 5. 播放器提示加载失败怎么办？
+### 播放器提示加载失败怎么办？
 
 先确认网络连接是否稳定，再点击播放器中的“重试”。如果仍失败，通常是播放地址过期、Cookie 失效、平台拒绝或本地媒体代理暂时无法取得资源。可以刷新详情、重新登录，或稍后再试。
 
-### 6. 自动更新失败怎么办？
+### 自动更新失败怎么办？
 
 自动更新依赖 GitHub Release。若当前网络无法访问 GitHub，可手动打开 Releases 页面下载对应平台的新版本安装包。
 
-### 7. 为什么头像或封面偶尔显示默认图？
+### 为什么头像或封面偶尔显示默认图？
 
 头像、封面由平台接口返回。接口未返回、图片过期或网络异常时，应用会显示默认占位图，不影响下载功能。
 
@@ -207,6 +238,7 @@ cargo tauri build
 - 接口可能随抖音策略变化而失效或返回结构变化
 - 某些平台首次运行需要额外系统权限或安全确认
 - 当前仍以桌面端本地使用为主，不是云服务方案
+- 移动端暂未产品化；如果后续尝试，会优先验证 Android WebView 登录和 Cookie 获取方案
 
 ---
 
@@ -214,13 +246,7 @@ cargo tauri build
 
 - 发现问题：欢迎提交 [Issue](https://github.com/anYuJia/douyin-downloader-rust/issues)
 - 想改进功能：欢迎发起 Pull Request
-- 提交前建议先本地运行：
-
-```bash
-cd src-tauri
-cargo fmt --check
-cargo test
-```
+- 发布与包管理器分发相关脚本见 [scripts](scripts) 和 [packaging/package-managers](packaging/package-managers)
 
 ---
 
@@ -242,4 +268,16 @@ cargo test
 
 ---
 
-<p align="center">觉得有用？给个 ⭐ Star 支持一下</p>
+## Star History
+
+<a href="https://star-history.com/#anYuJia/DY_video_downloader&Date">
+  <img src="https://api.star-history.com/svg?repos=anYuJia/DY_video_downloader&type=Date" width="100%" alt="DY_video_downloader Star History Chart">
+</a>
+
+<p align="center">
+  <a href="https://star-history.com/#anYuJia/DY_video_downloader&Date">https://star-history.com/#anYuJia/DY_video_downloader&Date</a>
+</p>
+
+---
+
+<p align="center">觉得有用？给个 Star 支持一下</p>

--- a/packaging/package-managers/README.md
+++ b/packaging/package-managers/README.md
@@ -20,15 +20,22 @@ Recommended order:
 
 ## Hashes
 
-Download the release assets and compute hashes:
+Download the release assets:
 
 ```bash
 VERSION=v0.0.9
 gh release download "$VERSION" --pattern 'Douyin.Downloader_*' --pattern 'Douyin-Downloader_*'
-shasum -a 256 Douyin.Downloader_*.dmg Douyin.Downloader_*_x64-setup.exe Douyin-Downloader_*_x64_portable.exe
 ```
 
-Use the hash values to replace placeholders in:
+Then generate version-pinned manifests:
+
+```bash
+VERSION=v0.0.9 node scripts/generate-package-manifests.mjs
+```
+
+The script computes SHA-256 hashes and writes files under `generated/<version>/`.
+
+The templates with placeholders are:
 
 - `homebrew/douyin-downloader.rb`
 - `scoop/douyin-downloader.json`

--- a/scripts/finalize-updater-metadata.mjs
+++ b/scripts/finalize-updater-metadata.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const version = process.env.VERSION || process.argv[2] || '';
+const repository = process.env.GITHUB_REPOSITORY || process.argv[3] || '';
+
+if (!version.startsWith('v')) {
+  throw new Error('VERSION must be a tag like v0.0.9');
+}
+if (!repository || !repository.includes('/')) {
+  throw new Error('GITHUB_REPOSITORY must be set, for example anYuJia/douyin-downloader-rust');
+}
+
+const appVersion = version.slice(1);
+const baseUrl = `https://github.com/${repository}/releases/download/${version}`;
+const previous = fs.existsSync('latest.json')
+  ? JSON.parse(fs.readFileSync('latest.json', 'utf8'))
+  : {};
+
+function findFile(pattern, label) {
+  const found = fs.readdirSync(process.cwd()).find((file) => pattern.test(file));
+  if (!found) {
+    throw new Error(`Missing ${label}`);
+  }
+  return found;
+}
+
+function readSignature(assetName) {
+  const sigPath = `${assetName}.sig`;
+  if (!fs.existsSync(sigPath)) {
+    throw new Error(`Missing signature file: ${sigPath}`);
+  }
+  return fs.readFileSync(sigPath, 'utf8').replace(/[\r\n]/g, '');
+}
+
+const assets = {
+  darwinArmApp: 'Douyin.Downloader_aarch64.app.tar.gz',
+  darwinX64App: 'Douyin.Downloader_x64.app.tar.gz',
+  windowsInstaller: `Douyin.Downloader_${appVersion}_x64-setup.exe`,
+  windowsPortable: `Douyin-Downloader_${appVersion}_x64_portable.exe`,
+  linuxAppImage: `Douyin.Downloader_${appVersion}_amd64.AppImage`,
+  linuxDeb: `Douyin.Downloader_${appVersion}_amd64.deb`,
+  linuxRpm: findFile(
+    new RegExp(`^Douyin\\.Downloader-${appVersion.replaceAll('.', '\\.')}-\\d+\\.x86_64\\.rpm\\.sig$`),
+    'RPM signature'
+  ).replace(/\.sig$/, '')
+};
+
+const metadata = {
+  version: appVersion,
+  notes: previous.notes || '',
+  pub_date: previous.pub_date || '',
+  platforms: {
+    'darwin-aarch64': {
+      signature: readSignature(assets.darwinArmApp),
+      url: `${baseUrl}/${assets.darwinArmApp}`
+    },
+    'darwin-aarch64-app': {
+      signature: readSignature(assets.darwinArmApp),
+      url: `${baseUrl}/${assets.darwinArmApp}`
+    },
+    'darwin-x86_64': {
+      signature: readSignature(assets.darwinX64App),
+      url: `${baseUrl}/${assets.darwinX64App}`
+    },
+    'darwin-x86_64-app': {
+      signature: readSignature(assets.darwinX64App),
+      url: `${baseUrl}/${assets.darwinX64App}`
+    },
+    'windows-x86_64': {
+      signature: readSignature(assets.windowsInstaller),
+      url: `${baseUrl}/${assets.windowsInstaller}`
+    },
+    'windows-x86_64-nsis': {
+      signature: readSignature(assets.windowsInstaller),
+      url: `${baseUrl}/${assets.windowsInstaller}`
+    },
+    'windows-x86_64-portable': {
+      signature: readSignature(assets.windowsPortable),
+      url: `${baseUrl}/${assets.windowsPortable}`
+    },
+    'linux-x86_64': {
+      signature: readSignature(assets.linuxAppImage),
+      url: `${baseUrl}/${assets.linuxAppImage}`
+    },
+    'linux-x86_64-appimage': {
+      signature: readSignature(assets.linuxAppImage),
+      url: `${baseUrl}/${assets.linuxAppImage}`
+    },
+    'linux-x86_64-deb': {
+      signature: readSignature(assets.linuxDeb),
+      url: `${baseUrl}/${assets.linuxDeb}`
+    },
+    'linux-x86_64-rpm': {
+      signature: readSignature(assets.linuxRpm),
+      url: `${baseUrl}/${assets.linuxRpm}`
+    }
+  }
+};
+
+for (const [target, data] of Object.entries(metadata.platforms)) {
+  if (!data.signature || !data.url) {
+    throw new Error(`Incomplete updater metadata for ${target}`);
+  }
+}
+
+for (const output of ['latest.json', 'darwin.json', 'windows.json', 'linux.json']) {
+  fs.writeFileSync(path.join(process.cwd(), output), `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+console.log(`Generated updater metadata for ${version}`);

--- a/scripts/generate-package-manifests.mjs
+++ b/scripts/generate-package-manifests.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const version = (process.env.VERSION || process.argv[2] || '').replace(/^v/, '');
+const releaseDir = path.resolve(process.env.RELEASE_DIR || process.argv[3] || process.cwd());
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error('Provide VERSION as 0.0.9 or v0.0.9');
+}
+
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(path.join(releaseDir, file))).digest('hex');
+}
+
+function readTemplate(relativePath) {
+  return fs.readFileSync(path.join(rootDir, 'packaging/package-managers', relativePath), 'utf8');
+}
+
+function writeGenerated(relativePath, content) {
+  const outputPath = path.join(rootDir, 'packaging/package-managers/generated', `v${version}`, relativePath);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, content);
+  console.log(`Wrote ${path.relative(rootDir, outputPath)}`);
+}
+
+const replacements = {
+  '{{VERSION}}': version,
+  '{{SHA256_DMG_ARM64}}': sha256(`Douyin.Downloader_${version}_aarch64.dmg`),
+  '{{SHA256_DMG_X64}}': sha256(`Douyin.Downloader_${version}_x64.dmg`),
+  '{{SHA256_WINDOWS_INSTALLER}}': sha256(`Douyin.Downloader_${version}_x64-setup.exe`).toUpperCase(),
+  '{{SHA256_WINDOWS_PORTABLE}}': sha256(`Douyin-Downloader_${version}_x64_portable.exe`)
+};
+
+function applyReplacements(content) {
+  return Object.entries(replacements).reduce(
+    (next, [needle, value]) => next.replaceAll(needle, value),
+    content
+  );
+}
+
+const files = [
+  ['homebrew/douyin-downloader.rb', 'homebrew/douyin-downloader.rb'],
+  ['scoop/douyin-downloader.json', 'scoop/douyin-downloader.json'],
+  ['winget/AnYuJia.DouyinDownloader/AnYuJia.DouyinDownloader.yaml', 'winget/AnYuJia.DouyinDownloader.yaml'],
+  ['winget/AnYuJia.DouyinDownloader/AnYuJia.DouyinDownloader.locale.zh-CN.yaml', 'winget/AnYuJia.DouyinDownloader.locale.zh-CN.yaml'],
+  ['winget/AnYuJia.DouyinDownloader/AnYuJia.DouyinDownloader.installer.yaml', 'winget/AnYuJia.DouyinDownloader.installer.yaml']
+];
+
+for (const [templatePath, outputPath] of files) {
+  writeGenerated(outputPath, applyReplacements(readTemplate(templatePath)));
+}


### PR DESCRIPTION
## 变更

- 抽出 updater 元数据生成脚本，Release 和手动恢复流程共用
- 增加手动 Finalize Updater Metadata workflow，可在构建成功但元数据步骤失败时单独恢复
- 增加包管理器 manifest 生成脚本，基于已下载 release 资产自动计算 SHA256
- 为 CI/Release 启用 GitHub Actions Node 24 兼容开关

## 验证

- node --check scripts/finalize-updater-metadata.mjs scripts/generate-package-manifests.mjs
- 用 v0.0.9 真实签名文件生成 updater JSON
- 用 v0.0.9 真实资产生成 package manager manifests
- workflow YAML 解析通过
- generated scoop JSON 与 winget YAML 校验通过